### PR TITLE
Fix for django >= 1.7

### DIFF
--- a/emailusernames/forms.py
+++ b/emailusernames/forms.py
@@ -36,7 +36,9 @@ class EmailAuthenticationForm(AuthenticationForm):
                 raise forms.ValidationError(self.message_incorrect_password)
             if not self.user_cache.is_active:
                 raise forms.ValidationError(self.message_inactive)
-        self.check_for_test_cookie()
+        #check_for_test_cookie was removed in django 1.7
+        if hasattr(self, 'check_for_test_cookie'):
+            self.check_for_test_cookie()
         return self.cleaned_data
 
 


### PR DESCRIPTION
I think the commit message says it all:
conditionally disable check_for_test_cookie as it was removed in django 1.7 (see https://docs.djangoproject.com/en/1.8/internals/deprecation/)
